### PR TITLE
FIX Ensure extension is actually applied before calling its methods

### DIFF
--- a/src/Extensions/CommentNotifier.php
+++ b/src/Extensions/CommentNotifier.php
@@ -24,7 +24,7 @@ class CommentNotifier extends Extension
     {
         $parent = $comment->Parent();
 
-        if (!$parent) {
+        if (!$parent || !$parent->hasMethod('notificationRecipients')) {
             return;
         }
 


### PR DESCRIPTION
This caused an issue when running the Comments test suite as part of the recipe-blog. See silverstripe/recipe-blog#5
