### PR TITLE
Remove branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,6 @@
             "SilverStripe\\CommentNotifications\\Tests\\": "tests/"
         }
     },
-	"extra": {
-		"branch-alias": {
-			"dev-master": "2.x-dev"
-		}
-	},
     "prefer-stable": true,
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
Remove branch to resolve the following issue when trying to install `cwp/cwp-recipe-kitchen-sink:2.x-dev`

```
 - silverstripe/recipe-blog 1.x-dev requires silverstripe/comment-notifications 2.x-dev -> no matching package found.
```