### PR TITLE
FIX Validate email correctly when in array format

### DIFF
--- a/src/Extensions/CommentNotifier.php
+++ b/src/Extensions/CommentNotifier.php
@@ -41,19 +41,21 @@ class CommentNotifier extends Extension
      *
      * @param Comment $comment
      * @param DataObject $parent Object with the {@see CommentNotifiable} extension applied
-     * @param Member|string $recipient Either a member object or an email address to which notifications should be sent
+     * @param Member|string|array $recipient Either a member object or an email address towhich notifications
+     * should be sent
      */
     public function notifyCommentRecipient($comment, $parent, $recipient)
     {
         $subject = $parent->notificationSubject($comment, $recipient);
         $sender = $parent->notificationSender($comment, $recipient);
         $template = $parent->notificationTemplate($comment, $recipient);
+        $to = ($recipient instanceof Member) ? $recipient->Email : $recipient;
 
         // Validate email
         // Important in case of the owner being a default-admin or a username with no contact email
-        $to = ($recipient instanceof Member) ? $recipient->Email : $recipient;
-
-        if (!Email::is_valid_address($to)) {
+        // Assume arrays are in email => name format
+        $validateTo = is_array($to) ? (array_keys($to)[0] ?? '') : $to;
+        if (!Email::is_valid_address($validateTo)) {
             return;
         }
 


### PR DESCRIPTION
Fixes error when posting a comment form as default admin
> Argument 1 passed to SilverStripe\Control\Email\Email::is_valid_address() must be of the type array, string given

## Alternative to
- https://github.com/silverstripe/comment-notifications/pull/47

## Replaces
- https://github.com/silverstripe/comment-notifications/pull/50

## Parent issue
- https://github.com/silverstripe/comment-notifications/issues/49