### PR TITLE
DEP Explicitly require framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
 	}],
 	"require": {
 		"php": "^8.1",
+		"silverstripe/framework": "^5",
 		"silverstripe/comments": "^4"
 	},
 	"require-dev": {


### PR DESCRIPTION
https://github.com/silverstripeltd/product-issues/issues/672

Means that CI knows which version of installer to use.  Currently it's mistakenly requiring `4` instead of `5`.

There's no downside to defining the version of framework here, rather than relying on the version defined in silverstripe/comments.
